### PR TITLE
Add dummy port for web service

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,8 @@
 PromptTracker Bot - בוט לניהול פרומפטים
 """
 import logging
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from telegram import Update
 from telegram.ext import (
     Application,
@@ -58,6 +60,53 @@ logging.basicConfig(
     level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+
+health_server = None
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """שרת HTTP קטן כדי להחזיק פורט פתוח לרנדר"""
+
+    def do_GET(self):
+        self._send_response()
+
+    def do_HEAD(self):
+        self._send_response(send_body=False)
+
+    def _send_response(self, send_body: bool = True):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        if send_body:
+            self.wfile.write(b"ok")
+
+    def log_message(self, format, *args):
+        # לא לרשום כל בקשה לכלוג
+        return
+
+
+def start_healthcheck_server():
+    """הפעלת שרת בריאות מינימלי כדי שלרנדר יהיה פורט פתוח"""
+    global health_server
+
+    if not config.ENABLE_HEALTHCHECK_SERVER:
+        logger.info("Health-check server disabled via ENABLE_HEALTHCHECK_SERVER env var")
+        return
+
+    port = config.HEALTHCHECK_PORT
+    try:
+        health_server = HTTPServer(("", port), HealthHandler)
+    except OSError as exc:
+        logger.warning("Failed to start health-check server on port %s: %s", port, exc)
+        return
+
+    thread = threading.Thread(
+        target=health_server.serve_forever,
+        name="render-healthcheck-server",
+        daemon=True
+    )
+    thread.start()
+    logger.info("Health-check server is listening on port %s", port)
 
 # ========== פקודות בסיס ==========
 
@@ -365,6 +414,7 @@ def main():
     application.add_error_handler(error_handler)
     
     # הפעלת הבוט
+    start_healthcheck_server()
     logger.info("🚀 Bot is starting...")
     application.run_polling(allowed_updates=Update.ALL_TYPES)
 

--- a/config.py
+++ b/config.py
@@ -41,3 +41,10 @@ MAX_PROMPT_LENGTH = 4000  # אורך מקסימלי לפרומפט
 PROMPTS_PER_PAGE = 10     # כמה פרומפטים בעמוד
 MAX_TAGS = 10             # מקסימום תגיות לפרומפט
 TRASH_RETENTION_DAYS = 30 # כמה ימים לשמור פרומפטים במחיקה
+
+# Health-check server (לרנדר)
+ENABLE_HEALTHCHECK_SERVER = os.getenv('ENABLE_HEALTHCHECK_SERVER', 'true').lower() not in {'false', '0', 'no', 'off'}
+try:
+    HEALTHCHECK_PORT = int(os.getenv('PORT') or os.getenv('HEALTHCHECK_PORT') or 8000)
+except (TypeError, ValueError):
+    HEALTHCHECK_PORT = 8000


### PR DESCRIPTION
Adds a minimal HTTP server to satisfy Render's open port requirement for web services.

When deployed as a web service on platforms like Render, a Telegram bot doesn't inherently open an HTTP port, leading to "No open ports detected" errors. This change introduces a small HTTP server to provide a port for Render's health checks, allowing the service to start correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3af7426f-0dc4-4d37-a926-f9e393c1186a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3af7426f-0dc4-4d37-a926-f9e393c1186a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

