### PR TITLE
Fix entity parsing errors in button text

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -133,12 +133,13 @@ async def start_command(update: Update, context):
         first_name=user.first_name
     )
     
+    from utils import escape_html
     welcome_text = (
-        f"👋 שלום {user.first_name}!\n\n"
-        f"ברוך הבא ל-*PromptTracker* 🚀\n\n"
+        f"👋 שלום {escape_html(user.first_name)}!\n\n"
+        f"ברוך הבא ל-<b>PromptTracker</b> 🚀\n\n"
         f"אני אעזור לך לנהל ולארגן את כל הפרומפטים שלך "
         f"למודלים של AI (ChatGPT, Claude, Midjourney ועוד).\n\n"
-        f"📋 *מה אני יכול לעשות?*\n"
+        f"📋 <b>מה אני יכול לעשות?</b>\n"
         f"• 💾 שמור פרומפטים בקלות\n"
         f"• 🔍 חפש ומצא במהירות\n"
         f"• 📁 ארגן לפי קטגוריות\n"
@@ -150,15 +151,15 @@ async def start_command(update: Update, context):
     
     await update.message.reply_text(
         welcome_text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=main_menu_keyboard()
     )
 
 async def help_command(update: Update, context):
     """פקודת /help"""
     help_text = (
-        "📚 *עזרה - PromptTracker*\n\n"
-        "*פקודות זמינות:*\n\n"
+        "📚 <b>עזרה - PromptTracker</b>\n\n"
+        "<b>פקודות זמינות:</b>\n\n"
         "🔹 /start - תפריט ראשי\n"
         "🔹 /save - שמור פרומפט חדש\n"
         "🔹 /list - הצג את כל הפרומפטים\n"
@@ -169,7 +170,7 @@ async def help_command(update: Update, context):
         "🔹 /tags - תגיות\n"
         "🔹 /trash - סל מחזור\n"
         "🔹 /settings - הגדרות\n\n"
-        "*טיפים:*\n"
+        "<b>טיפים:</b>\n"
         "💡 אתה יכול להעביר (Forward) הודעות עם פרומפטים\n"
         "💡 השתמש בתגיות כדי לארגן טוב יותר\n"
         "💡 הפרומפטים הכי משומשים מופיעים בראש ברשימה\n\n"
@@ -178,7 +179,7 @@ async def help_command(update: Update, context):
     
     await update.message.reply_text(
         help_text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=main_menu_keyboard()
     )
 
@@ -203,7 +204,7 @@ async def show_settings(update: Update, context):
 
     await (query.edit_message_text if query else update.message.reply_text)(
         text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=back_button("back_main")
     )
 
@@ -214,14 +215,14 @@ async def stats_command(update: Update, context):
     
     user_stats = stats['user']
     
-    text = "📊 *הסטטיסטיקות שלך*\n\n"
-    text += f"📋 סה״כ פרומפטים: *{user_stats.get('total_prompts', 0)}*\n"
-    text += f"🔢 סה״כ שימושים: *{user_stats.get('total_uses', 0)}*\n"
-    text += f"⭐ מועדפים: *{db.count_prompts(user.id, is_favorite=True)}*\n\n"
+    text = "📊 <b>הסטטיסטיקות שלך</b>\n\n"
+    text += f"📋 סה״כ פרומפטים: <b>{user_stats.get('total_prompts', 0)}</b>\n"
+    text += f"🔢 סה״כ שימושים: <b>{user_stats.get('total_uses', 0)}</b>\n"
+    text += f"⭐ מועדפים: <b>{db.count_prompts(user.id, is_favorite=True)}</b>\n\n"
     
     # קטגוריות פופולריות
     if stats['categories']:
-        text += "📁 *קטגוריות מובילות:*\n"
+        text += "📁 <b>קטגוריות מובילות:</b>\n"
         for cat in stats['categories'][:5]:
             emoji = config.CATEGORY_EMOJIS.get(cat['_id'], '📄')
             text += f"  {emoji} {cat['_id']}: {cat['count']}\n"
@@ -229,20 +230,20 @@ async def stats_command(update: Update, context):
     
     # תגיות פופולריות
     if stats['tags']:
-        text += "🏷️ *תגיות פופולריות:*\n"
+        text += "🏷️ <b>תגיות פופולריות:</b>\n"
         for tag in stats['tags'][:5]:
             text += f"  #{tag['_id']}: {tag['count']}\n"
     
     if update.callback_query:
         await update.callback_query.edit_message_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
 
@@ -250,18 +251,27 @@ async def trash_command(update: Update, context):
     """הצגת סל מחזור"""
     user = update.effective_user
     trash_items = db.get_trash(user.id)
+    query = update.callback_query
     
     if not trash_items:
-        text = "🗑️ *סל המחזור*\n\nהסל ריק."
-        await update.message.reply_text(
-            text,
-            parse_mode='Markdown',
-            reply_markup=back_button("back_main")
-        )
+        text = "🗑️ <b>סל המחזור</b>\n\nהסל ריק."
+        if query:
+            await query.answer()
+            await query.edit_message_text(
+                text,
+                parse_mode='HTML',
+                reply_markup=back_button("back_main")
+            )
+        else:
+            await update.message.reply_text(
+                text,
+                parse_mode='HTML',
+                reply_markup=back_button("back_main")
+            )
         return
     
-    text = f"🗑️ *סל המחזור* ({len(trash_items)})\n\n"
-    text += "_פרומפטים נמחקים לצמיתות אחרי 30 יום_\n\n"
+    text = f"🗑️ <b>סל המחזור</b> ({len(trash_items)})\n\n"
+    text += "<i>פרומפטים נמחקים לצמיתות אחרי 30 יום</i>\n\n"
     
     for i, prompt in enumerate(trash_items[:20], 1):
         emoji = config.CATEGORY_EMOJIS.get(prompt['category'], '📄')
@@ -272,15 +282,22 @@ async def trash_command(update: Update, context):
         deleted_at = prompt.get('deleted_at')
         if deleted_at:
             days_ago = (db.prompts.database.client.server_info()['localTime'] - deleted_at).days
-            text += f"{i}. {emoji} *{title}*\n"
+            text += f"{i}. {emoji} <b>{title}</b>\n"
             text += f"   נמחק לפני {days_ago} ימים\n"
-            text += f"   /restore\\_{str(prompt['_id'])}\n\n"
-    
-    await update.message.reply_text(
-        text,
-        parse_mode='MarkdownV2',
-        reply_markup=back_button("back_main")
-    )
+            text += f"   /restore_{str(prompt['_id'])}\n\n"
+    if query:
+        await query.answer()
+        await query.edit_message_text(
+            text,
+            parse_mode='HTML',
+            reply_markup=back_button("back_main")
+        )
+    else:
+        await update.message.reply_text(
+            text,
+            parse_mode='HTML',
+            reply_markup=back_button("back_main")
+        )
 
 async def restore_command(update: Update, context):
     """שחזור פרומפט מהאשפה"""
@@ -316,8 +333,8 @@ async def button_handler(update: Update, context):
     if data == "back_main":
         await query.answer()
         await query.edit_message_text(
-            "📋 *PromptTracker*\n\nבחר פעולה:",
-            parse_mode='Markdown',
+            "📋 <b>PromptTracker</b>\n\nבחר פעולה:",
+            parse_mode='HTML',
             reply_markup=main_menu_keyboard()
         )
         return
@@ -459,6 +476,7 @@ def main():
     application.add_handler(CallbackQueryHandler(manage_tags, pattern="^tags_"))
     application.add_handler(CallbackQueryHandler(remove_tag, pattern="^rmtag_"))
     application.add_handler(CallbackQueryHandler(show_settings, pattern="^settings$"))
+    application.add_handler(CallbackQueryHandler(trash_command, pattern="^trash$"))
 
     # Conversation Handler להוספת תגית
     tags_conv = ConversationHandler(

--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -15,6 +15,7 @@ from keyboards import (
 )
 import config
 from bson import ObjectId
+from utils import escape_html, code_block, code_inline
 
 # States
 EDITING_CONTENT, EDITING_TITLE = range(2)
@@ -39,25 +40,25 @@ async def view_my_prompts(update: Update, context: ContextTypes.DEFAULT_TYPE):
     total_count = db.count_prompts(user.id)
     
     if not prompts:
-        text = "📋 *הפרומפטים שלי*\n\n"
+        text = "📋 <b>הפרומפטים שלי</b>\n\n"
         text += "אין לך פרומפטים שמורים עדיין.\n\n"
         text += "השתמש ב-/save כדי לשמור את הפרומפט הראשון שלך! 💾"
         
         if query:
             await query.edit_message_text(
                 text,
-                parse_mode='Markdown',
+                parse_mode='HTML',
                 reply_markup=back_button("back_main")
             )
         else:
             await update.message.reply_text(
                 text,
-                parse_mode='Markdown'
+                parse_mode='HTML'
             )
         return
     
     # בניית הטקסט
-    text = f"📋 *הפרומפטים שלי* ({total_count} סה״כ)\n\n"
+    text = f"📋 <b>הפרומפטים שלי</b> ({total_count} סה״כ)\n\n"
     
     for i, prompt in enumerate(prompts, start=skip + 1):
         emoji = config.CATEGORY_EMOJIS.get(prompt['category'], '📄')
@@ -67,16 +68,16 @@ async def view_my_prompts(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if len(title) > 40:
             title = title[:40] + "..."
         
-        text += f"{i}. {fav}{emoji} *{title}*\n"
-        text += f"   📁 {prompt['category']} | "
+        text += f"{i}. {fav}{emoji} <b>{escape_html(title)}</b>\n"
+        text += f"   📁 {escape_html(prompt['category'])} | "
         text += f"🔢 {prompt['use_count']} שימושים\n"
         
         # תגיות
         if prompt.get('tags'):
-            tags_str = " ".join([f"#{tag}" for tag in prompt['tags'][:3]])
+            tags_str = " ".join([f"#{escape_html(tag)}" for tag in prompt['tags'][:3]])
             text += f"   🏷️ {tags_str}\n"
         
-        text += f"   /view\\_{str(prompt['_id'])}\n\n"
+        text += f"   /view_{str(prompt['_id'])}\n\n"
     
     # דפדוף
     total_pages = (total_count + config.PROMPTS_PER_PAGE - 1) // config.PROMPTS_PER_PAGE
@@ -84,13 +85,13 @@ async def view_my_prompts(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if query:
         await query.edit_message_text(
             text,
-            parse_mode='MarkdownV2',
+            parse_mode='HTML',
             reply_markup=pagination_keyboard(page, total_pages, "page")
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='MarkdownV2',
+            parse_mode='HTML',
             reply_markup=pagination_keyboard(page, total_pages, "page")
         )
 
@@ -135,19 +136,19 @@ async def view_prompt_details(update: Update, context: ContextTypes.DEFAULT_TYPE
     emoji = config.CATEGORY_EMOJIS.get(prompt['category'], '📄')
     fav = "⭐ " if prompt.get('is_favorite') else ""
     
-    text = f"{fav}*{prompt['title']}*\n"
+    text = f"{fav}<b>{escape_html(prompt['title'])}</b>\n"
     text += f"{'━' * 30}\n\n"
-    text += f"{prompt['content']}\n\n"
+    text += f"{escape_html(prompt['content'])}\n\n"
     text += f"{'━' * 30}\n"
-    text += f"📊 *פרטים:*\n"
-    text += f"• מזהה: `{prompt_id}`\n"
-    text += f"• קטגוריה: {emoji} {prompt['category']}\n"
+    text += f"📊 <b>פרטים:</b>\n"
+    text += f"• מזהה: {code_inline(prompt_id)}\n"
+    text += f"• קטגוריה: {emoji} {escape_html(prompt['category'])}\n"
     text += f"• אורך: {prompt['length']} תווים\n"
     text += f"• שימושים: {prompt['use_count']} פעמים\n"
     text += f"• נוצר: {prompt['created_at'].strftime('%d/%m/%Y')}\n"
     
     if prompt.get('tags'):
-        tags_str = " ".join([f"#{tag}" for tag in prompt['tags']])
+        tags_str = " ".join([f"#{escape_html(tag)}" for tag in prompt['tags']])
         text += f"• תגיות: {tags_str}\n"
     
     keyboard = prompt_actions_keyboard(prompt_id, prompt.get('is_favorite', False))
@@ -155,13 +156,13 @@ async def view_prompt_details(update: Update, context: ContextTypes.DEFAULT_TYPE
     if query:
         await query.edit_message_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=keyboard
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=keyboard
         )
 
@@ -185,10 +186,12 @@ async def copy_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # שליחת הפרומפט כהודעה שניתן להעתיק
     await context.bot.send_message(
         chat_id=user.id,
-        text=f"📋 *{prompt['title']}*\n\n"
-             f"```\n{prompt['content']}\n```\n\n"
-             f"_לחץ על הטקסט כדי להעתיק_",
-        parse_mode='Markdown'
+        text=(
+            f"📋 <b>{escape_html(prompt['title'])}</b>\n\n"
+            f"{code_block(prompt['content'])}\n\n"
+            f"<i>לחץ על הטקסט כדי להעתיק</i>"
+        ),
+        parse_mode='HTML'
     )
     
     await query.answer("✅ הפרומפט נשלח! העתק את הטקסט מההודעה", show_alert=False)
@@ -227,9 +230,9 @@ async def start_edit_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE):
     prompt_id = query.data.replace('edit_', '')
     
     await query.edit_message_text(
-        "✏️ *עריכת פרומפט*\n\n"
+        "✏️ <b>עריכת פרומפט</b>\n\n"
         "מה תרצה לערוך?",
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=edit_menu_keyboard(prompt_id)
     )
 
@@ -242,10 +245,10 @@ async def start_edit_content(update: Update, context: ContextTypes.DEFAULT_TYPE)
     context.user_data['editing_prompt_id'] = prompt_id
     
     await query.edit_message_text(
-        "📝 *עריכת תוכן*\n\n"
+        "📝 <b>עריכת תוכן</b>\n\n"
         "שלח את התוכן החדש לפרומפט.\n\n"
         "או שלח /cancel לביטול.",
-        parse_mode='Markdown'
+        parse_mode='HTML'
     )
     
     return EDITING_CONTENT
@@ -285,10 +288,10 @@ async def start_edit_title(update: Update, context: ContextTypes.DEFAULT_TYPE):
     context.user_data['editing_prompt_id'] = prompt_id
     
     await query.edit_message_text(
-        "📋 *עריכת כותרת*\n\n"
+        "📋 <b>עריכת כותרת</b>\n\n"
         "שלח את הכותרת החדשה.\n\n"
         "או שלח /cancel לביטול.",
-        parse_mode='Markdown'
+        parse_mode='HTML'
     )
     
     return EDITING_TITLE
@@ -300,8 +303,8 @@ async def start_change_category(update: Update, context: ContextTypes.DEFAULT_TY
     prompt_id = query.data.replace('chcat_', '')
     context.user_data['changing_category_for'] = prompt_id
     await query.edit_message_text(
-        "📁 *שינוי קטגוריה*\n\nבחר קטגוריה חדשה:",
-        parse_mode='Markdown',
+        "📁 <b>שינוי קטגוריה</b>\n\nבחר קטגוריה חדשה:",
+        parse_mode='HTML',
         reply_markup=category_keyboard(include_all=False)
     )
     return CHANGING_CATEGORY
@@ -375,10 +378,10 @@ async def delete_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE):
     prompt_id = query.data.replace('delete_', '')
     
     await query.edit_message_text(
-        "⚠️ *מחיקת פרומפט*\n\n"
+        "⚠️ <b>מחיקת פרומפט</b>\n\n"
         "האם אתה בטוח שברצונך למחוק את הפרומפט?\n"
         "ניתן יהיה לשחזר אותו מסל המחזור תוך 30 יום.",
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=confirm_keyboard('delete', prompt_id)
     )
 
@@ -423,15 +426,15 @@ async def view_favorites(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     if not prompts:
         await query.edit_message_text(
-            "⭐ *המועדפים שלי*\n\n"
+            "⭐ <b>המועדפים שלי</b>\n\n"
             "אין לך פרומפטים מועדפים עדיין.\n\n"
             "הוסף פרומפטים למועדפים דרך כפתור ⭐",
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
         return
     
-    text = f"⭐ *המועדפים שלי* ({len(prompts)})\n\n"
+    text = f"⭐ <b>המועדפים שלי</b> ({len(prompts)})\n\n"
     
     for i, prompt in enumerate(prompts[:20], 1):  # מגביל ל-20
         emoji = config.CATEGORY_EMOJIS.get(prompt['category'], '📄')
@@ -439,11 +442,11 @@ async def view_favorites(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if len(title) > 40:
             title = title[:40] + "..."
         
-        text += f"{i}. {emoji} *{title}*\n"
-        text += f"   /view\\_{str(prompt['_id'])}\n\n"
+        text += f"{i}. {emoji} <b>{escape_html(title)}</b>\n"
+        text += f"   /view_{str(prompt['_id'])}\n\n"
     
     await query.edit_message_text(
         text,
-        parse_mode='MarkdownV2',
+        parse_mode='HTML',
         reply_markup=back_button("back_main")
     )

--- a/handlers/save.py
+++ b/handlers/save.py
@@ -6,6 +6,7 @@ from telegram.ext import ContextTypes, ConversationHandler
 from database import db
 from keyboards import category_keyboard, prompt_actions_keyboard, back_button
 import config
+from utils import escape_html
 
 # States for conversation
 WAITING_FOR_PROMPT, WAITING_FOR_TITLE, WAITING_FOR_CATEGORY = range(3)
@@ -14,22 +15,22 @@ async def start_save_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """התחלת תהליך שמירת פרומפט"""
     query = update.callback_query
     text = (
-        "📝 *שמירת פרומפט חדש*\n\n"
+        "📝 <b>שמירת פרומפט חדש</b>\n\n"
         "שלח לי את הפרומפט שברצונך לשמור.\n"
         "אתה יכול גם להעביר (Forward) הודעה קיימת.\n\n"
-        "💡 _טיפ: הפרומפט יכול להיות עד 4000 תווים_"
+        "💡 <i>טיפ: הפרומפט יכול להיות עד 4000 תווים</i>"
     )
     if query:
         await query.answer()
         await query.edit_message_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     return WAITING_FOR_PROMPT
@@ -62,10 +63,10 @@ async def receive_prompt_content(update: Update, context: ContextTypes.DEFAULT_T
     
     await update.message.reply_text(
         f"✅ הפרומפט התקבל!\n\n"
-        f"📄 *תצוגה מקדימה:*\n"
-        f"_{preview}_\n\n"
+        f"📄 <b>תצוגה מקדימה:</b>\n"
+        f"<i>{escape_html(preview)}</i>\n\n"
         f"📋 כעת, שלח כותרת לפרומפט (או שלח דלג):",
-        parse_mode='Markdown'
+        parse_mode='HTML'
     )
     
     return WAITING_FOR_TITLE
@@ -83,9 +84,9 @@ async def receive_prompt_title(update: Update, context: ContextTypes.DEFAULT_TYP
     
     # בקשת קטגוריה
     await update.message.reply_text(
-        f"✅ הכותרת נשמרה: *{title}*\n\n"
+        f"✅ הכותרת נשמרה: <b>{escape_html(title)}</b>\n\n"
         f"📁 כעת, בחר קטגוריה:",
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=category_keyboard(include_all=False)
     )
     
@@ -117,13 +118,13 @@ async def receive_prompt_category(update: Update, context: ContextTypes.DEFAULT_
     emoji = config.CATEGORY_EMOJIS.get(category, '📄')
     
     await query.edit_message_text(
-        f"✅ *הפרומפט נשמר בהצלחה!*\n\n"
-        f"📋 *{title}*\n"
-        f"📁 קטגוריה: {emoji} {category}\n"
+        f"✅ <b>הפרומפט נשמר בהצלחה!</b>\n\n"
+        f"📋 <b>{escape_html(title)}</b>\n"
+        f"📁 קטגוריה: {emoji} {escape_html(category)}\n"
         f"📏 אורך: {len(content)} תווים\n"
-        f"🆔 מזהה: `{str(prompt['_id'])}`\n\n"
-        f"_הפרומפט זמין לשימוש!_",
-        parse_mode='Markdown',
+        f"🆔 מזהה: <code>{str(prompt['_id'])}</code>\n\n"
+        f"<i>הפרומפט זמין לשימוש!</i>",
+        parse_mode='HTML',
         reply_markup=prompt_actions_keyboard(str(prompt['_id']))
     )
     

--- a/handlers/search.py
+++ b/handlers/search.py
@@ -6,6 +6,7 @@ from telegram.ext import ContextTypes, ConversationHandler
 from database import db
 from keyboards import category_keyboard, back_button, prompt_list_item_keyboard
 import config
+from utils import escape_html
 
 # States
 WAITING_FOR_SEARCH_QUERY = 0
@@ -14,22 +15,22 @@ async def start_search(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """התחלת חיפוש"""
     query = update.callback_query
     text = (
-        "🔍 *חיפוש פרומפטים*\n\n"
+        "🔍 <b>חיפוש פרומפטים</b>\n\n"
         "שלח מילת חיפוש או ביטוי לחיפוש בכל הפרומפטים שלך.\n\n"
-        "💡 _טיפ: החיפוש מתבצע בכותרת ובתוכן הפרומפט_\n\n"
+        "💡 <i>טיפ: החיפוש מתבצע בכותרת ובתוכן הפרומפט</i>\n\n"
         "או שלח /cancel לביטול."
     )
     if query:
         await query.answer()
         await query.edit_message_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     
@@ -52,15 +53,15 @@ async def receive_search_query(update: Update, context: ContextTypes.DEFAULT_TYP
     
     if not results:
         await update.message.reply_text(
-            f"🔍 לא נמצאו תוצאות עבור: *{query_text}*\n\n"
+            f"🔍 לא נמצאו תוצאות עבור: <b>{escape_html(query_text)}</b>\n\n"
             f"נסה מילות חיפוש אחרות.",
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
         return ConversationHandler.END
     
     # הצגת תוצאות
-    text = f"🔍 *תוצאות חיפוש:* \"{query_text}\"\n"
+    text = f"🔍 <b>תוצאות חיפוש:</b> \"{escape_html(query_text)}\"\n"
     text += f"נמצאו {len(results)} תוצאות\n\n"
     
     for i, prompt in enumerate(results, 1):
@@ -71,13 +72,13 @@ async def receive_search_query(update: Update, context: ContextTypes.DEFAULT_TYP
         if len(title) > 40:
             title = title[:40] + "..."
         
-        text += f"{i}. {fav}{emoji} *{title}*\n"
-        text += f"   📁 {prompt['category']}\n"
-        text += f"   /view\\_{str(prompt['_id'])}\n\n"
+        text += f"{i}. {fav}{emoji} <b>{escape_html(title)}</b>\n"
+        text += f"   📁 {escape_html(prompt['category'])}\n"
+        text += f"   /view_{str(prompt['_id'])}\n\n"
     
     await update.message.reply_text(
         text,
-        parse_mode='MarkdownV2',
+        parse_mode='HTML',
         reply_markup=back_button("back_main")
     )
     
@@ -102,16 +103,16 @@ async def filter_by_category(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if not prompts:
         emoji = config.CATEGORY_EMOJIS.get(category, '📄')
         await query.edit_message_text(
-            f"📁 *{emoji} {category}*\n\n"
+            f"📁 <b>{emoji} {escape_html(category)}</b>\n\n"
             f"אין פרומפטים בקטגוריה זו.",
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("categories")
         )
         return
     
     # הצגת תוצאות
     emoji = config.CATEGORY_EMOJIS.get(category, '📄')
-    text = f"📁 *{emoji} {category}*\n"
+    text = f"📁 <b>{emoji} {escape_html(category)}</b>\n"
     text += f"נמצאו {len(prompts)} פרומפטים\n\n"
     
     for i, prompt in enumerate(prompts[:20], 1):
@@ -121,13 +122,13 @@ async def filter_by_category(update: Update, context: ContextTypes.DEFAULT_TYPE)
         if len(title) > 40:
             title = title[:40] + "..."
         
-        text += f"{i}. {fav}*{title}*\n"
+        text += f"{i}. {fav}<b>{escape_html(title)}</b>\n"
         text += f"   🔢 {prompt['use_count']} שימושים\n"
-        text += f"   /view\\_{str(prompt['_id'])}\n\n"
+        text += f"   /view_{str(prompt['_id'])}\n\n"
     
     await query.edit_message_text(
         text,
-        parse_mode='MarkdownV2',
+        parse_mode='HTML',
         reply_markup=back_button("categories")
     )
 
@@ -139,17 +140,17 @@ async def show_categories_menu(update: Update, context: ContextTypes.DEFAULT_TYP
     user = update.effective_user
     
     # ספירת פרומפטים לכל קטגוריה
-    text = "📁 *קטגוריות*\n\n"
+    text = "📁 <b>קטגוריות</b>\n\n"
     text += "בחר קטגוריה לצפייה:\n\n"
     
     for emoji, category in config.CATEGORIES.items():
         count = db.count_prompts(user.id, category=category)
         if count > 0:
-            text += f"{emoji} *{category}*: {count} פרומפטים\n"
+            text += f"{emoji} <b>{escape_html(category)}</b>: {count} פרומפטים\n"
     
     await query.edit_message_text(
         text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=category_keyboard(include_all=True)
     )
 
@@ -163,27 +164,27 @@ async def show_tags_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     if not tags:
         await query.edit_message_text(
-            "🏷️ *תגיות*\n\n"
+            "🏷️ <b>תגיות</b>\n\n"
             "אין עדיין תגיות.\n\n"
             "הוסף תגיות לפרומפטים שלך כדי לארגן אותם טוב יותר!",
-            parse_mode='Markdown',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
         return
     
-    text = "🏷️ *התגיות שלי*\n\n"
+    text = "🏷️ <b>התגיות שלי</b>\n\n"
     text += "התגיות הפופולריות ביותר:\n\n"
     
     for i, tag in enumerate(tags[:20], 1):
         # ספירת שימושים
         count = len(db.search_prompts(user.id, tags=[tag], limit=100))
-        text += f"{i}. #{tag} ({count})\n"
+        text += f"{i}. #{escape_html(tag)} ({count})\n"
     
-    text += f"\n_סה״כ {len(tags)} תגיות_"
+    text += f"\n<i>סה״כ {len(tags)} תגיות</i>"
     
     await query.edit_message_text(
         text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=back_button("back_main")
     )
 
@@ -193,11 +194,11 @@ async def show_popular_prompts(update: Update, context: ContextTypes.DEFAULT_TYP
     prompts = db.get_popular_prompts(user.id, limit=10)
     
     if not prompts:
-        text = "🔥 *פרומפטים פופולריים*\n\n"
+        text = "🔥 <b>פרומפטים פופולריים</b>\n\n"
         text += "אין עדיין נתונים על שימוש.\n\n"
         text += "השתמש בפרומפטים שלך (העתק) כדי לאסוף נתונים."
     else:
-        text = "🔥 *הפרומפטים הפופולריים ביותר*\n\n"
+        text = "🔥 <b>הפרומפטים הפופולריים ביותר</b>\n\n"
         
         for i, prompt in enumerate(prompts, 1):
             emoji = config.CATEGORY_EMOJIS.get(prompt['category'], '📄')
@@ -207,19 +208,19 @@ async def show_popular_prompts(update: Update, context: ContextTypes.DEFAULT_TYP
             if len(title) > 40:
                 title = title[:40] + "..."
             
-            text += f"{i}. {fav}{emoji} *{title}*\n"
+            text += f"{i}. {fav}{emoji} <b>{escape_html(title)}</b>\n"
             text += f"   🔢 {prompt['use_count']} שימושים\n"
-            text += f"   /view\\_{str(prompt['_id'])}\n\n"
+            text += f"   /view_{str(prompt['_id'])}\n\n"
     
     if update.callback_query:
         await update.callback_query.edit_message_text(
             text,
-            parse_mode='MarkdownV2',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )
     else:
         await update.message.reply_text(
             text,
-            parse_mode='MarkdownV2',
+            parse_mode='HTML',
             reply_markup=back_button("back_main")
         )

--- a/handlers/tags.py
+++ b/handlers/tags.py
@@ -6,6 +6,7 @@ from telegram.ext import ContextTypes, ConversationHandler
 from database import db
 from keyboards import tag_management_keyboard, back_button
 import config
+from utils import escape_html
 
 # States
 WAITING_FOR_NEW_TAG = 0
@@ -26,21 +27,21 @@ async def manage_tags(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     existing_tags = prompt.get('tags', [])
     
-    text = f"🏷️ *ניהול תגיות*\n\n"
-    text += f"📋 פרומפט: {prompt['title']}\n\n"
+    text = f"🏷️ <b>ניהול תגיות</b>\n\n"
+    text += f"📋 פרומפט: {escape_html(prompt['title'])}\n\n"
     
     if existing_tags:
         text += f"תגיות קיימות ({len(existing_tags)}):\n"
         for tag in existing_tags:
-            text += f"• #{tag}\n"
+            text += f"• #{escape_html(tag)}\n"
     else:
-        text += "_אין עדיין תגיות_\n"
+        text += "<i>אין עדיין תגיות</i>\n"
     
-    text += f"\n💡 _תגיות עוזרות למצוא פרומפטים במהירות_"
+    text += f"\n💡 <i>תגיות עוזרות למצוא פרומפטים במהירות</i>"
     
     await query.edit_message_text(
         text,
-        parse_mode='Markdown',
+        parse_mode='HTML',
         reply_markup=tag_management_keyboard(prompt_id, existing_tags)
     )
 
@@ -53,14 +54,14 @@ async def start_add_tag(update: Update, context: ContextTypes.DEFAULT_TYPE):
     context.user_data['adding_tag_to'] = prompt_id
     
     await query.edit_message_text(
-        "🏷️ *הוספת תגית חדשה*\n\n"
+        "🏷️ <b>הוספת תגית חדשה</b>\n\n"
         "שלח את שם התגית (ללא #)\n\n"
         "דוגמאות:\n"
-        "• `python`\n"
-        "• `telegram-bot`\n"
-        "• `beginner`\n\n"
+        "• <code>python</code>\n"
+        "• <code>telegram-bot</code>\n"
+        "• <code>beginner</code>\n\n"
         "או שלח /cancel לביטול.",
-        parse_mode='Markdown'
+        parse_mode='HTML'
     )
     
     return WAITING_FOR_NEW_TAG
@@ -100,8 +101,8 @@ async def receive_new_tag(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     if tag in existing_tags:
         await update.message.reply_text(
-            f"⚠️ התגית `#{tag}` כבר קיימת!",
-            parse_mode='Markdown'
+            f"⚠️ התגית <code>#{escape_html(tag)}</code> כבר קיימת!",
+            parse_mode='HTML'
         )
         return WAITING_FOR_NEW_TAG
     
@@ -117,8 +118,8 @@ async def receive_new_tag(update: Update, context: ContextTypes.DEFAULT_TYPE):
     db.update_prompt(prompt_id, user.id, {'tags': existing_tags})
     
     await update.message.reply_text(
-        f"✅ התגית `#{tag}` נוספה!",
-        parse_mode='Markdown',
+        f"✅ התגית <code>#{escape_html(tag)}</code> נוספה!",
+        parse_mode='HTML',
         reply_markup=back_button(f"tags_{prompt_id}")
     )
     

--- a/keyboards.py
+++ b/keyboards.py
@@ -21,6 +21,9 @@ def main_menu_keyboard():
             InlineKeyboardButton("🏷️ תגיות", callback_data="tags")
         ],
         [
+            InlineKeyboardButton("🗑️ סל מחזור", callback_data="trash"),
+        ],
+        [
             InlineKeyboardButton("📊 סטטיסטיקות", callback_data="stats"),
             InlineKeyboardButton("⚙️ הגדרות", callback_data="settings")
         ]

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,30 @@
+"""
+Utilities for safely rendering text in Telegram with HTML parse mode.
+"""
+
+from typing import Any
+
+
+def escape_html(value: Any) -> str:
+    """Escape &, <, > for Telegram HTML parse mode.
+
+    Accepts any value and returns a safe string.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def code_inline(value: Any) -> str:
+    """Wrap a short value as inline code, HTML-escaped."""
+    return f"<code>{escape_html(value)}</code>"
+
+
+def code_block(value: Any) -> str:
+    """Wrap a value in a pre/code block, HTML-escaped."""
+    return f"<pre><code>{escape_html(value)}</code></pre>"


### PR DESCRIPTION
Migrate to HTML parse mode and escape dynamic text to fix 'Can't parse entities' errors and improve bot reliability.

The previous `MarkdownV2` parse mode caused 'Can't parse entities' errors when dynamic text (e.g., prompt titles, categories) contained special characters like parentheses or periods, especially when combined with bold formatting. This PR switches all message sending/editing to HTML parse mode and introduces utility functions to escape dynamic content, resolving these parsing issues. Additionally, it fixes several unresponsive buttons and implements a new trash/restore feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-69fafdd4-e72b-4b5d-8d76-888f208c9706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69fafdd4-e72b-4b5d-8d76-888f208c9706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

