### PR TITLE
Debug bot prompt view command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -30,6 +30,7 @@ from handlers.save import (
 from handlers.manage import (
     view_my_prompts,
     view_prompt_details,
+    handle_view_command_text,
     copy_prompt,
     toggle_favorite,
     start_edit_prompt,
@@ -372,9 +373,12 @@ def main():
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("list", view_my_prompts))
+    application.add_handler(CommandHandler("view", handle_view_command_text))
     application.add_handler(CommandHandler("stats", stats_command))
     application.add_handler(CommandHandler("trash", trash_command))
     application.add_handler(CommandHandler("restore", restore_command))
+    # תמיכה גם בצורה /view_<id>
+    application.add_handler(MessageHandler(filters.Regex(r"^/view_[0-9a-fA-F]{24}$"), handle_view_command_text))
     
     # Conversation Handler לשמירת פרומפט
     save_conv = ConversationHandler(

--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -166,6 +166,28 @@ async def view_prompt_details(update: Update, context: ContextTypes.DEFAULT_TYPE
             reply_markup=keyboard
         )
 
+async def handle_view_command_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """תמיכה בפקודת /view וב-/view_<id> הנשלחים כטקסט"""
+    message = update.message
+    prompt_id = None
+
+    if message and message.text:
+        text = message.text.strip()
+        # צורה 1: /view_<id>
+        if text.startswith('/view_'):
+            prompt_id = text.split('/view_', 1)[1].strip()
+        # צורה 2: /view <id>
+        elif context.args:
+            prompt_id = context.args[0]
+
+    if not prompt_id:
+        await update.message.reply_text("⚠️ שימוש: /view <prompt_id>")
+        return
+
+    # איחוד הזרימה דרך נתיב ה-callback הקיים
+    context.user_data['callback_data'] = f"view_{prompt_id}"
+    await view_prompt_details(update, context)
+
 async def copy_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """העתקת פרומפט"""
     query = update.callback_query


### PR DESCRIPTION
Add support for `/view_<id>` and `/view <id>` commands to allow users to view prompt details via text commands.

The "My Prompts" list displayed commands in the `/view_<id>` format, but the bot only had a handler for `view_` callback queries from inline buttons, not for these textual commands. This PR introduces a handler to parse both `/view_<id>` and `/view <id>` and route them to the existing prompt details flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-85991e2d-932b-4706-98ec-a794a70f9d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85991e2d-932b-4706-98ec-a794a70f9d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

