### PR TITLE
Respond to github message and tag user

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -450,7 +450,6 @@ def main():
     application.add_handler(change_cat_conv)
     
     # Callback handlers
-    application.add_handler(CallbackQueryHandler(exit_search_mode_on_callback, block=False))
     application.add_handler(CallbackQueryHandler(view_my_prompts, pattern="^my_prompts$"))
     application.add_handler(CallbackQueryHandler(view_my_prompts, pattern="^page_"))
     application.add_handler(CallbackQueryHandler(view_prompt_details, pattern="^view_"))
@@ -485,6 +484,8 @@ def main():
     application.add_handler(tags_conv)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, receive_search_query))
     application.add_handler(CallbackQueryHandler(stats_command, pattern="^stats$"))
+    # ניקוי מצב החיפוש לאחר שטופלו שאר ה-handlers הספציפיים
+    application.add_handler(CallbackQueryHandler(exit_search_mode_on_callback, block=False))
     
     # Callback כללי
     application.add_handler(CallbackQueryHandler(button_handler))


### PR DESCRIPTION
Reorder `exit_search_mode_on_callback` handler to restore responsiveness of specific buttons.

The generic `exit_search_mode_on_callback` handler was registered before specific button handlers, causing it to intercept callbacks and make buttons like `הפרומפטים שלי` and `מועדפים` appear unresponsive. Moving it to run after specific handlers ensures correct button functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd6d3516-70b7-4b20-9d8c-32aa952d498a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd6d3516-70b7-4b20-9d8c-32aa952d498a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

