### PR TITLE
Implement distributed locking for bot instances

### DIFF
--- a/distributed_lock.py
+++ b/distributed_lock.py
@@ -1,0 +1,218 @@
+"""
+MongoDB-based distributed lock with TTL and heartbeat.
+"""
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import random
+import signal
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from pymongo import MongoClient, ASCENDING, ReturnDocument
+from pymongo.collection import Collection
+from pymongo.errors import PyMongoError
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LockConfig:
+    service_id: str
+    instance_id: str
+    host: str
+    lease_seconds: int
+    heartbeat_interval: int
+    wait_for_acquire: bool
+    acquire_max_wait: int  # seconds, 0 = unlimited
+    backoff_min_seconds: int
+    backoff_max_seconds: int
+
+
+class MongoDistributedLock:
+    def __init__(
+        self,
+        mongo_uri: str,
+        db_name: str,
+        collection_name: str = "bot_locks",
+        lock_cfg: Optional[LockConfig] = None,
+    ) -> None:
+        self.client = MongoClient(mongo_uri)
+        self.db = self.client[db_name]
+        self.collection: Collection = self.db[collection_name]
+
+        # Build config with fallbacks
+        hostname = socket.gethostname() or "unknown-host"
+        pid = os.getpid()
+        instance_id = (
+            config.RENDER_INSTANCE_ID
+            or os.getenv("INSTANCE_ID")
+            or f"{hostname}:{pid}"
+        )
+        host = config.RENDER_SERVICE_NAME or hostname
+
+        self.cfg = lock_cfg or LockConfig(
+            service_id=config.SERVICE_ID,
+            instance_id=instance_id,
+            host=host,
+            lease_seconds=max(5, int(config.LOCK_LEASE_SECONDS)),
+            heartbeat_interval=max(5, int(config.LOCK_HEARTBEAT_INTERVAL)),
+            wait_for_acquire=bool(config.LOCK_WAIT_FOR_ACQUIRE),
+            acquire_max_wait=max(0, int(config.LOCK_ACQUIRE_MAX_WAIT)),
+            backoff_min_seconds=max(1, int(config.LOCK_WAIT_MIN_SECONDS)),
+            backoff_max_seconds=max(1, int(config.LOCK_WAIT_MAX_SECONDS)),
+        )
+
+        # Internal state
+        self._stop_event = threading.Event()
+        self._hb_thread: Optional[threading.Thread] = None
+        self._is_owner = False
+
+        self._ensure_indexes()
+
+        # Ensure clean release on shutdown
+        atexit.register(self.release)
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                signal.signal(sig, self._handle_signal)
+            except Exception:
+                # Not all environments allow setting signals (e.g., threads)
+                pass
+
+    def _ensure_indexes(self) -> None:
+        try:
+            # TTL index on expiresAt ensures orphaned locks are cleared automatically
+            self.collection.create_index(
+                [("expiresAt", ASCENDING)], name="ttl_expiresAt", expireAfterSeconds=0
+            )
+        except PyMongoError as exc:
+            logger.warning("Failed to ensure TTL index on bot_locks: %s", exc)
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _try_acquire(self) -> bool:
+        now = self._now()
+        expires = now + timedelta(seconds=self.cfg.lease_seconds)
+        try:
+            doc = self.collection.find_one_and_update(
+                {
+                    "_id": self.cfg.service_id,
+                    "$or": [
+                        {"expiresAt": {"$lte": now}},  # expired
+                        {"owner": self.cfg.instance_id},  # re-entrance by same owner
+                        {"expiresAt": {"$exists": False}},  # not initialized
+                    ],
+                },
+                {
+                    "$set": {
+                        "owner": self.cfg.instance_id,
+                        "host": self.cfg.host,
+                        "updatedAt": now,
+                        "expiresAt": expires,
+                    },
+                    "$setOnInsert": {"createdAt": now},
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+            if doc and doc.get("owner") == self.cfg.instance_id:
+                self._is_owner = True
+                logger.info(
+                    "Acquired distributed lock '%s' as %s on %s (lease=%ss)",
+                    self.cfg.service_id,
+                    self.cfg.instance_id,
+                    self.cfg.host,
+                    self.cfg.lease_seconds,
+                )
+                return True
+            return False
+        except PyMongoError as exc:
+            logger.error("Lock acquire attempt failed: %s", exc)
+            return False
+
+    def acquire_blocking(self) -> None:
+        start_ts = time.time()
+        if self.cfg.wait_for_acquire:
+            # Active wait with optional max timeout
+            while not self._try_acquire():
+                if self.cfg.acquire_max_wait > 0 and (time.time() - start_ts) > self.cfg.acquire_max_wait:
+                    logger.warning(
+                        "Lock acquire timed out after %ss; exiting.",
+                        self.cfg.acquire_max_wait,
+                    )
+                    # Exit gracefully to allow platform to restart us later
+                    raise SystemExit(0)
+                time.sleep(1)
+        else:
+            # Passive wait with randomized backoff; never exits
+            while not self._try_acquire():
+                backoff = random.uniform(
+                    self.cfg.backoff_min_seconds, self.cfg.backoff_max_seconds
+                )
+                logger.info(
+                    "Lock held by another instance. Waiting %.1fs before retry...",
+                    backoff,
+                )
+                time.sleep(backoff)
+
+    def start_heartbeat(self) -> None:
+        if not self._is_owner:
+            return
+        if self._hb_thread and self._hb_thread.is_alive():
+            return
+        self._hb_thread = threading.Thread(target=self._heartbeat_loop, name="lock-heartbeat", daemon=True)
+        self._hb_thread.start()
+
+    def _heartbeat_loop(self) -> None:
+        while not self._stop_event.is_set():
+            time.sleep(self.cfg.heartbeat_interval)
+            if self._stop_event.is_set():
+                break
+            now = self._now()
+            new_expiry = now + timedelta(seconds=self.cfg.lease_seconds)
+            try:
+                result = self.collection.update_one(
+                    {"_id": self.cfg.service_id, "owner": self.cfg.instance_id},
+                    {"$set": {"expiresAt": new_expiry, "updatedAt": now}},
+                    upsert=False,
+                )
+                if result.matched_count == 0:
+                    logger.error("Lost distributed lock; terminating to avoid duplicate polling")
+                    os._exit(0)
+            except PyMongoError as exc:
+                logger.error("Heartbeat failed: %s", exc)
+                # Keep trying; a transient error shouldn't drop the lock immediately
+
+    def release(self) -> None:
+        if not self._is_owner:
+            return
+        self._stop_event.set()
+        try:
+            self.collection.delete_one(
+                {"_id": self.cfg.service_id, "owner": self.cfg.instance_id}
+            )
+            logger.info(
+                "Released distributed lock '%s' from %s",
+                self.cfg.service_id,
+                self.cfg.instance_id,
+            )
+        except Exception as exc:
+            logger.warning("Failed to release lock: %s", exc)
+        finally:
+            self._is_owner = False
+
+    def _handle_signal(self, signum, frame):  # noqa: D401
+        # Release lock and exit promptly
+        try:
+            self.release()
+        finally:
+            raise SystemExit(0)


### PR DESCRIPTION
Adds a MongoDB-based distributed lock to prevent Telegram 409 Conflict errors caused by multiple bot instances, which led to unresponsive bot interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c43290d2-7e29-4dbd-b815-3a6d57a87921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c43290d2-7e29-4dbd-b815-3a6d57a87921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

