### PR TITLE
Fix unresponsive add category button

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -595,7 +595,8 @@ def main():
         fallbacks=[
             CommandHandler("cancel", cancel_category_edit),
             CallbackQueryHandler(cancel_category_edit, pattern="^catcfg_manage$")
-        ]
+        ],
+        allow_reentry=True
     )
     application.add_handler(category_conv)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, receive_search_query))


### PR DESCRIPTION
Enable re-entry for the category management conversation to fix the unresponsive "Add new category" button.

The button was unresponsive because the `ConversationHandler` did not allow re-entry, causing the callback to fall through if a previous attempt was not properly completed or cancelled. Adding `allow_reentry=True` ensures the add/edit flow restarts reliably.

---
<a href="https://cursor.com/background-agent?bcId=bc-74041d65-feed-43f9-b053-eaabe5b659d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74041d65-feed-43f9-b053-eaabe5b659d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

